### PR TITLE
Add src, docs, and tests for extending validator with custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,41 @@ See validation rule usage in [Laravel Documentation](https://laravel.com/docs/5.
 - size
 - string
 - url
+
+## Extending with Custom Validation Rules
+
+The validator can be extended with custom rules
+
+```javascript
+    var rules = {
+        id: 'required|mongoid'
+    }
+
+    function validateMongoId(name, value, params) {
+        let hexadecimal = /^[0-9A-F]+$/i
+        return value && hexadecimal.test(value) && value.length === 24
+    }
+    
+    var v = Validator.make(data, rules)
+    v.extend('mongoid', validateMongoId, ":attr is not a valid mongo id")
+
+    
+    if (v.passes()) {
+        //...
+    }
+```
+
+`validator.extend` takes three _required_ parameters:
+
+* `name`: the name of the custom rule
+* `callback`: called when the rule is checked
+* `validationMessage`: error message text on validation failure
+
+The validation callback receives three parameters:
+
+1. `name`: the field name being validated
+2. `value`: the given value in the data
+3. `params`: Any parameters, passed after the colon in the rule definition.
+ 
+Params defined ike so: `rulename:min=10,max=15` would be passed in as an array: `['min=10', 'max=15']`
+

--- a/test/Validator.test.js
+++ b/test/Validator.test.js
@@ -95,7 +95,6 @@ describe('Validator', function() {
     })
     describe('#extend()', function() {
         let isMongoId = (name, value, args) => {
-            console.log(args);
             let hexadecimal = /^[0-9A-F]+$/i
             return value && hexadecimal.test(value) && value.length === 24
         }

--- a/test/Validator.test.js
+++ b/test/Validator.test.js
@@ -93,6 +93,38 @@ describe('Validator', function() {
             expect(arr).to.be.null
         })
     })
+    describe('#extend()', function() {
+        let isMongoId = (name, value, args) => {
+            console.log(args);
+            let hexadecimal = /^[0-9A-F]+$/i
+            return value && hexadecimal.test(value) && value.length === 24
+        }
+        let rules = {
+            id: 'mongoid:min=24,max=24',
+        }
+        let v = Validator.make({
+            id: '5915b8434479e9b7e11db37c'
+        }, rules)
+        v.extend('mongoid', isMongoId, ':attr must be a valid mongo id')
+
+        let fail_v = Validator.make({
+            id: 'asdfasfdw'
+        }, rules)
+        fail_v.extend('mongoid', isMongoId, ':attr must be a valid mongo id')
+
+        it('can be extended with a custom rule', function() {            
+            expect(v.findRuleMethod({name: 'Mongoid'})).to.equal(isMongoId)
+        })
+        it('runs custom validation rule', function() {            
+            expect(v.passes(data)).to.be.true
+            expect(fail_v.passes()).to.be.false
+        })
+        it('custom validator fails with custom message', function() {            
+            expect(fail_v.getErrors()).to.deep.equal({
+                id: ['id must be a valid mongo id']
+            })
+        })
+    })
     describe('#hasError()', function() {
         it('returns true if there is any error', function() {
             let v = Validator.make({name: 'Test'}, {


### PR DESCRIPTION
Hey @ratiw : thanks for a nice package. I'm a big fan of Laravel's validation.

I've added in an `extend` method so that users can write custom validation rules. Pretty close the version available in Laravel 5.2.

What do you think? 