### PR TITLE
Added nullable rule.

### DIFF
--- a/dist/Validator.js
+++ b/dist/Validator.js
@@ -237,6 +237,13 @@ var Validator = function () {
             }
         }
     }, {
+        key: 'isEmptyValueAndContainsNullableRule',
+        value: function isEmptyValueAndContainsNullableRule(item) {
+            return !this.getValue(item.name) && item.rules.filter(function (rule) {
+                return rule.name === 'Nullable';
+            }).length > 0;
+        }
+    }, {
         key: 'passes',
         value: function passes() {
             var self = this;
@@ -245,7 +252,10 @@ var Validator = function () {
 
             this.rules.forEach(function (item) {
                 var name = item.name;
-                item.rules.forEach(function (rule) {
+                if (self.isEmptyValueAndContainsNullableRule(item)) return false;
+                item.rules.filter(function (rule) {
+                    return rule.name !== 'Nullable';
+                }).forEach(function (rule) {
                     self.validate(name, rule);
                 });
             });

--- a/src/Validator.js
+++ b/src/Validator.js
@@ -145,6 +145,10 @@ export default class Validator {
         }
     }
 
+    isEmptyValueAndContainsNullableRule(item){
+        return !this.getValue(item.name) && item.rules.filter(rule => rule.name === 'Nullable').length > 0;
+    }
+
     passes() {
         let self = this
         this.errors = {}
@@ -152,7 +156,9 @@ export default class Validator {
 
         this.rules.forEach(function(item) {
             let name = item.name;
-            item.rules.forEach(function(rule) {
+             if(self.isEmptyValueAndContainsNullableRule(item))
+                return false;
+            item.rules.filter(rule => rule.name !== 'Nullable').forEach(function(rule) {
                 self.validate(name, rule)
             })
         })

--- a/test/Validator.test.js
+++ b/test/Validator.test.js
@@ -1282,6 +1282,29 @@ describe('Validator', function() {
             })
         })
     })
+
+    describe('# nullable rule tests' , () => {
+        it('should passed a empty date with "nullable" rule' , () => {
+            let v = Validator.make({
+                name: 'adrian'
+            } , {
+                name: 'required|string',
+                lastName: 'nullable|string'
+            });
+            expect(v.passes()).to.be.true;
+        });
+
+        it('should passed a date with "nullable" rule' , () => {
+            let v = Validator.make({
+                name: 'adrian',
+                lastName: 'locurcio'
+            } , {
+                name: 'required|string',
+                lastName: 'nullable|string'
+            });
+            expect(v.passes()).to.be.true;
+        });
+    })
 })
 
 /*


### PR DESCRIPTION
Added nullable rule because for exampe I pass a 'email' rule to a field an the field not exists the valdiator rejects the field and saying that the fields is not a 'email' valid. With nullable rule if the field not exists and has 'nullable' rule the validator will not validate the field with the others rules and will passed.